### PR TITLE
fix: wrap octet-stream in Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ module.exports = class Comparer {
       }
     })
 
-    const latest = JSON.parse(asset.data)
+    const latest = JSON.parse(Buffer.from(asset.data))
     return parseCoverage(latest)
   }
 


### PR DESCRIPTION
This is needed to properly handle encoding.

Ref: LOG-9626
Semver: patch
